### PR TITLE
feat: Add support for specifying the ciphertext encoding options

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,12 @@ type DecryptArgs = {
   salt: string,
 };
 
-const createEnvelopeEncryptor = keyService => {
+const defaults = {
+  encoding: 'hex'
+}
+
+const createEnvelopeEncryptor = (keyService, options = defaults) => {
+  const { encoding } = options
   const algorithm = 'aes256'
 
   const { getDataKey, decryptDataKey } = keyService
@@ -19,8 +24,9 @@ const createEnvelopeEncryptor = keyService => {
     const cipher = crypto.createCipheriv(algorithm, plaintextKey, salt)
     const ciphertext = [
       cipher.update(plaintext, 'utf8'),
-      cipher.final('hex')
+      cipher.final(encoding)
     ].join('')
+
     return {
       ciphertext,
       key: encryptedKey,
@@ -32,7 +38,7 @@ const createEnvelopeEncryptor = keyService => {
     const dataKey = await decryptDataKey(key)
     const decipher = crypto.createDecipheriv(algorithm, dataKey, salt)
     return [
-      decipher.update(ciphertext, 'hex', 'utf8'),
+      decipher.update(ciphertext, encoding, 'utf8'),
       decipher.final('utf8')
     ].join('')
   }

--- a/index.test.js
+++ b/index.test.js
@@ -16,9 +16,23 @@ const keyService = {
   decryptDataKey: key => Promise.resolve(plaintextKey)
 }
 
-const encryptor = createEnvelopeEncryptor(keyService)
+t.test('envelope encryptor', async t => {
+  const encryptor = createEnvelopeEncryptor(keyService)
 
-t.test('envelope encrypter', async t => {
+  const result = await encryptor.encrypt('secret message')
+  const { key } = result
+  t.equal(key, 'foo', 'encryptedKey is from keyService.getDataKey')
+  const secretMessage = await encryptor.decrypt(result)
+  t.equal(
+    secretMessage,
+    'secret message',
+    'given ciphertext, key and salt decrypt returns plaintext message'
+  )
+})
+
+t.test('envelope encryptor - supports changing ciphertext encoding format ', async t => {
+  const encryptor = createEnvelopeEncryptor(keyService, { encoding: 'base64' })
+
   const result = await encryptor.encrypt('secret message')
   const { key } = result
   t.equal(key, 'foo', 'encryptedKey is from keyService.getDataKey')


### PR DESCRIPTION
Add an options parameter to createEnvelopeEncryptor which allows
the specification of an encoding format the ciphertext will be
constructed in. The default encoding is set to 'hex'.