### PR TITLE
fix: Specify encrypt cipher.update to specify output encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const createEnvelopeEncryptor = (keyService, options = defaults) => {
     const salt = Buffer.from(crypto.randomBytes(8)).toString('hex')
     const cipher = crypto.createCipheriv(algorithm, plaintextKey, salt)
     const ciphertext = [
-      cipher.update(plaintext, 'utf8'),
+      cipher.update(plaintext, 'utf8', encoding),
       cipher.final(encoding)
     ].join('')
 

--- a/index.test.js
+++ b/index.test.js
@@ -16,30 +16,38 @@ const keyService = {
   decryptDataKey: key => Promise.resolve(plaintextKey)
 }
 
-t.test('envelope encryptor', async t => {
-  const encryptor = createEnvelopeEncryptor(keyService)
+const tests = [
+  'smallSecret',
+  'mediumSecretLength',
+  'superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLongStringWithLotsOfChararctersThatWillBeEncryptedAndDecryptedProperly'
+]
 
-  const result = await encryptor.encrypt('secret message')
-  const { key } = result
-  t.equal(key, 'foo', 'encryptedKey is from keyService.getDataKey')
-  const secretMessage = await encryptor.decrypt(result)
-  t.equal(
-    secretMessage,
-    'secret message',
-    'given ciphertext, key and salt decrypt returns plaintext message'
-  )
-})
+tests.forEach((plaintextInput) => {
+  t.test('envelope encryptor', async t => {
+    const encryptor = createEnvelopeEncryptor(keyService)
 
-t.test('envelope encryptor - supports changing ciphertext encoding format ', async t => {
-  const encryptor = createEnvelopeEncryptor(keyService, { encoding: 'base64' })
+    const result = await encryptor.encrypt(plaintextInput)
+    const { key } = result
+    t.equal(key, 'foo', 'encryptedKey is from keyService.getDataKey')
+    const secretMessage = await encryptor.decrypt(result)
+    t.equal(
+      secretMessage,
+      plaintextInput,
+      'given ciphertext, key and salt decrypt returns plaintext message'
+    )
+  })
 
-  const result = await encryptor.encrypt('secret message')
-  const { key } = result
-  t.equal(key, 'foo', 'encryptedKey is from keyService.getDataKey')
-  const secretMessage = await encryptor.decrypt(result)
-  t.equal(
-    secretMessage,
-    'secret message',
-    'given ciphertext, key and salt decrypt returns plaintext message'
-  )
+  t.test('envelope encryptor - supports changing ciphertext encoding format ', async t => {
+    const encryptor = createEnvelopeEncryptor(keyService, { encoding: 'base64' })
+
+    const result = await encryptor.encrypt(plaintextInput)
+    const { key } = result
+    t.equal(key, 'foo', 'encryptedKey is from keyService.getDataKey')
+    const secretMessage = await encryptor.decrypt(result)
+    t.equal(
+      secretMessage,
+      plaintextInput,
+      'given ciphertext, key and salt decrypt returns plaintext message'
+    )
+  })
 })


### PR DESCRIPTION
When encrypting a message, we were not specifying the output encoding
when updating the cipher. This was causing an issue with the ciper
padding length due to a mismatch of encodings. The result of this was
any attempt to encrypt & decrypt text longer than 15 characters would
fail. We now specify the output encoding when calling cipher.update
to fix the issue.