### PR TITLE
fix: handle Uint8Array CipherTextBlobs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,58 +1,47 @@
 declare module '@autotelic/envelope-encryptor' {
+  import { createCipheriv } from 'node:crypto'
+  import { KMS, KMSClientResolvedConfig } from '@aws-sdk/client-kms'
 
-  export interface AwsKmsConfig {
-    region?: string;
-    credentials?: {
-      accessKeyId?: string;
-      secretAccessKey?: string;
-    };
+  export type CipherKey = Parameters<typeof createCipheriv>[1]
+
+  export interface KeyService {
+    getDataKey: () => Promise<{
+      encryptedKey: string
+      plaintextKey: CipherKey
+    }>
+    decryptDataKey: (key: string) => Promise<CipherKey>
   }
 
-  export interface AwsKmsClient {
-    generateDataKey: (params: {
-      KeyId: string;
-      KeySpec: 'AES_256';
-    }) => { promise: () => Promise<{ CiphertextBlob: Buffer; Plaintext: Buffer }> };
+  export interface AwsKmsConfig extends KMSClientResolvedConfig {}
 
-    decrypt: (params: {
-      CiphertextBlob: Buffer;
-    }) => { promise: () => Promise<{ Plaintext: Buffer }> };
-  }
+  export type AwsKmsClient = Pick<KMS, 'generateDataKey' | 'decrypt'>
 
-  export interface AwsKmsService {
-    getDataKey: () => Promise<{ encryptedKey: string; plaintextKey: Buffer }>;
-    decryptDataKey: (key: string) => Promise<Buffer>;
-  }
+  export interface AwsKmsService extends KeyService {}
 
   export function awsKms(
     keyId: string,
     config?: AwsKmsConfig,
     Client?: new (config?: AwsKmsConfig) => AwsKmsClient
-  ): AwsKmsService;
-
-  export interface KeyService {
-    getDataKey: () => Promise<{ encryptedKey: string; plaintextKey: Buffer }>;
-    decryptDataKey: (key: string) => Promise<Buffer>;
-  }
+  ): AwsKmsService
 
   export interface EncryptorOptions {
-    encoding?: 'hex';
+    encoding?: 'hex'
   }
 
   export interface EncryptedData {
-    ciphertext: string;
-    key: Buffer;
-    salt: string;
+    ciphertext: string
+    key: string
+    salt: string
   }
 
   export interface EnvelopeEncryptor {
-    encrypt: (plaintext: string) => Promise<EncryptedData>;
-    decrypt: (data: EncryptedData) => Promise<string>;
+    encrypt: (plaintext: string) => Promise<EncryptedData>
+    decrypt: (data: EncryptedData) => Promise<string>
   }
 
   export function createEnvelopeEncryptor(
     keyService: KeyService,
     options?: EncryptorOptions
-  ): EnvelopeEncryptor;
+  ): EnvelopeEncryptor
 
 }

--- a/lib/awsKms.js
+++ b/lib/awsKms.js
@@ -11,7 +11,7 @@ const awsKms = (keyId, config = {}, Client = AWS.KMS) => {
       })
 
     return {
-      encryptedKey: CiphertextBlob.toString('base64'),
+      encryptedKey: (Buffer.from(CiphertextBlob)).toString('base64'),
       plaintextKey: Plaintext
     }
   }

--- a/lib/awsKms.test.js
+++ b/lib/awsKms.test.js
@@ -4,16 +4,16 @@ import awsKms from './awsKms.js'
 
 const config = { foo: 'bar' }
 const keyId = 'keyId'
-const ciphertextBlob = Buffer.from('thing')
-const encryptedKey = ciphertextBlob.toString('base64')
-
+const ciphertextBlob = Uint8Array.from('thing')
+const encryptedKey = Buffer.from(ciphertextBlob).toString('base64')
+const plaintextKey = Uint8Array.from('something')
 const Client = sinon.stub()
 const generateDataKeyStub = sinon.stub().returns({
   CiphertextBlob: ciphertextBlob,
-  Plaintext: 'something'
+  Plaintext: plaintextKey
 })
 const decryptStub = sinon.stub().returns({
-  Plaintext: 'something'
+  Plaintext: plaintextKey
 })
 
 Client.prototype.generateDataKey = generateDataKeyStub
@@ -37,7 +37,7 @@ t.test('awsKms', async t => {
       result,
       {
         encryptedKey,
-        plaintextKey: 'something'
+        plaintextKey
       },
       'and returns encrypted and plaintext keys'
     )
@@ -47,6 +47,6 @@ t.test('awsKms', async t => {
     decryptStub.calledWithExactly({
       CiphertextBlob: ciphertextBlob
     })
-    t.equal(result, 'something', 'and returns plaintext key')
+    t.equal(result, plaintextKey, 'and returns plaintext key')
   })
 })

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "tap": "^15.0.10"
   },
   "dependencies": {
-    "@aws-sdk/client-kms": "^3.529.1"
+    "@aws-sdk/client-kms": "^3.555.0"
   }
 }


### PR DESCRIPTION
### Summary

 - Update `awsKms` to handle `CiphertextBlob` as a `Uint8Array`
   - Previously was handling it as a `Buffer` which is no longer the case ([docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-kms/Interface/GenerateDataKeyCommandOutput/))
   - Update test stubs to return expected types
 - Update type delcarations 

### Test plan
 - Using `yalc` add this package to our auth project
 - Implement `awsKms` and pass it to `createEnvelopeEncryptor` in the DB seeds
 - Confirm seeds run without error
