### PR TITLE
Key service with KEK as config arg to support GCP secrets manager

### DIFF
--- a/examples/kekService/index.js
+++ b/examples/kekService/index.js
@@ -1,0 +1,19 @@
+import crypto from 'crypto'
+import { createEnvelopeEncryptor, kekService } from '../../index.js'
+
+;(async function () {
+  const base64Kek = crypto.randomBytes(32).toString('base64')
+  const kms = kekService(base64Kek)
+  const { encrypt, decrypt } = createEnvelopeEncryptor(kms)
+
+  const plaintext = 'Hello, world!'
+
+  // encrypted is object containing ciphertext, key, and salt to store in db
+  const encrypted = await encrypt(plaintext)
+
+  // pass encrypted object to decrypt function to get plaintext
+  const decrypted = await decrypt(encrypted)
+
+  console.log(decrypted) // Hello, world!
+
+}())

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import crypto from 'crypto'
 export { default as awsKms } from './lib/awsKms.js'
 export { default as dummyKms } from './lib/dummyKms.js'
+export { default as kekService } from './lib/kekService.js'
 
 const defaults = {
   encoding: 'hex'

--- a/lib/kekService.js
+++ b/lib/kekService.js
@@ -1,0 +1,39 @@
+import crypto from 'crypto'
+
+const kekService = (base64Kek) => {
+  const algorithm = 'aes256'
+  const encoding = 'hex'
+  const kek = Buffer.from(base64Kek, 'base64')
+
+  const getDataKey = async () => {
+    const plaintextKey = Buffer.from(crypto.randomBytes(32))
+    const salt = Buffer.from(crypto.randomBytes(8)).toString('hex')
+
+    const cipher = crypto.createCipheriv(algorithm, kek, salt)
+    const ciphertext = [
+      cipher.update(plaintextKey.toString('base64'), 'utf8', encoding),
+      cipher.final(encoding)
+    ].join('')
+    return Promise.resolve({
+      encryptedKey: `${ciphertext}:${salt}`,
+      plaintextKey
+    })
+  }
+
+  const decryptDataKey = async key => {
+    const [ciphertext, salt] = key.split(':')
+    const decipher = crypto.createDecipheriv(algorithm, kek, salt)
+    const decipheredtext = [
+      decipher.update(ciphertext, encoding, 'utf8'),
+      decipher.final('utf8')
+    ].join('')
+    return Buffer.from(decipheredtext, 'base64')
+  }
+
+  return {
+    getDataKey,
+    decryptDataKey
+  }
+}
+
+export default kekService

--- a/lib/kekService.test.js
+++ b/lib/kekService.test.js
@@ -1,0 +1,19 @@
+import crypto from 'crypto'
+import t from 'tap'
+import sinon from 'sinon'
+import kekService from './kekService.js'
+
+const base64Kek = crypto.randomBytes(32).toString('base64')
+const kms = kekService(base64Kek)
+
+t.test('kekService', async t => {
+  const { encryptedKey, plaintextKey } = await kms.getDataKey()
+  t.test('getDataKey', async t => {
+    t.type(encryptedKey, 'string')
+    t.type(plaintextKey, Buffer)
+  })
+  t.test('decryptDataKey', async t => {
+    const decryptedKey = await kms.decryptDataKey(encryptedKey)
+    t.same(decryptedKey, plaintextKey)
+  })
+})


### PR DESCRIPTION
## Summary

In order to support GCP secrets manager on Cloud Run, this adds a key service option which takes a key encryption key (KEK) as a base64 encoded string. This is to support storing the KEK in GCP secrets manager and then attaching it to the cloud run service as an env var at runtime.

## Test Plan

- run the tests `npm test`
- run the example `node examples/kekService/index.js` (should output `Hello, world!`)